### PR TITLE
Setting a pet name with spaces in it no longer ends with a trailing space

### DIFF
--- a/src/com/michaelelin/Barnyard/commands/NameCommand.java
+++ b/src/com/michaelelin/Barnyard/commands/NameCommand.java
@@ -49,11 +49,11 @@ public class NameCommand extends BarnyardCommand {
                     String newName = args[1];
                     
                     if (args.length > 2) {
-                        StringBuilder sb = new StringBuilder();
+                        StringBuilder sb = new StringBuilder(newName);
                         // Join our list of args with spaces
-                        for (int i = 1; i < args.length; i++) {
-                            sb.append(args[i]);
+                        for (int i = 2; i < args.length; i++) {
                             sb.append(" ");
+                            sb.append(args[i]);
                         }
                         newName = sb.toString();
                     }

--- a/src/com/michaelelin/Barnyard/commands/SpawnCommand.java
+++ b/src/com/michaelelin/Barnyard/commands/SpawnCommand.java
@@ -15,13 +15,13 @@ public class SpawnCommand extends BarnyardCommand {
     @Override
     public boolean execute(CommandSender sender, String[] args) {
         if (!checkArgs(args)) return false;
-        if (!checkPermission(sender, "barnyard.spawn")) return true;
+        if (!checkPermission(sender, "barnyard.spawn") && !checkPermission(sender, "barnyard.spawnany")) return true;
         if (sender instanceof Player) {
             Player player = (Player) sender;
             if (plugin.manager.canSpawnPet(player)) {
                 try {
                     EntityType type = EntityType.valueOf(args[0].toUpperCase());
-                    if (plugin.ALLOWED_TYPES.contains(type)) {
+                    if (plugin.ALLOWED_TYPES.contains(type) || checkPermission(sender, "barnyard.spawnany")) {
                         plugin.manager.spawnPet(type, player);
                     } else {
                         plugin.message(sender, "Allowed types: " + plugin.ALLOWED_TYPES.toString());

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -21,6 +21,8 @@ permissions:
       barnyard.other.*: true
   barnyard.spawn:
     description: Gives access to the /pet spawn command
+  barnyard.spawnany:
+    description: Gives access to spawn anything
   barnyard.remove:
     description: Gives access to the /pet remove command
   barnyard.list:


### PR DESCRIPTION
I'm testing out my new build tools. I also fixed a microscopic problem in Barnyard.
