### PR TITLE
Version 0.1.3 - Spigot 1.9 Compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin
 .project
 
 .settings
+/classes/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+Barnyard
+========
+Manages summonable pets.
+
+
+Commands
+--------
+
+ * `/pet spawn <type>` - Spawn a pet of the specified type. The default
+   configured types are: BAT, CHICKEN, COW, HORSE, IRON_GOLEM, MUSHROOM_COW,
+   OCELOT, PIG, SHEEP, SQUID and WOLF.
+ * `/pet remove [<player>] <id>` - Remove your own pet with the specified
+   1-based ID, or the pet of another player. Removing another player's pet
+   requires the `barnyard.other.remove` permission.
+ * `/pet list [<player>]` - List your own pets or those of another
+   player. Listing another player's pets requires the `barnyard.other.list`
+   permission.
+ * `/pet wear [<id>]` - Wear the specified pet on your head.
+ * `/pet ride <id>` - Ride the specified pet.
+ * `/pet stack <id> <id> [<id>...]` - Stack your pets one on top of the
+   other. The first ID specified is the bottom of the stack.
+ * `/pet name <id> [<name>]` - Assign a name to the pet with the specified
+   ID, or clear its name if no name is given.
+ * `/pet explode <id>` - Remove the specified pet with an explosion.
+
+
+Configuration
+-------------
+
+ * `maximum-pets` - Maximum number of pets per player (default: 3).
+ * `allowed-types` - A list of entity type names that can be spawned.
+   See [enum EntityType](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/EntityType.html).
+
+
+Permissions
+-----------
+
+ * `barnyard.spawn` - Gives access to the `/pet spawn` command.
+ * `barnyard.spawnany` - Gives access to spawn anything.
+ * `barnyard.remove` - Gives access to the `/pet remove` command.
+ * `barnyard.list` - Gives access to the `/pet list` command.
+ * `barnyard.wear` - Gives access to the `/pet wear` command.
+ * `barnyard.ride` - Gives access to the `/pet ride` command.
+ * `barnyard.stack` - Gives access to the `/pet stack` command.
+ * `barnyard.name` - Gives access to the `/pet name` command.
+ * `barnyard.explode` - Gives access to the `/pet explode` command.
+ * `barnyard.other.remove` - Gives access to the `/pet remove <player> <id> command`.
+ * `barnyard.other.list` - Gives access to the `/pet list <player>` command.
+ * `barnyard.other.*` - Gives access to all Barnyard moderation commands.
+   Equivalent to these permissions:
+   * `barnyard.other.remove`
+   * `barnyard.other.list`
+ * `barnyard.*` - Gives access to all Barnyard commands. Includes all
+   permissions listed above.

--- a/pom.xml
+++ b/pom.xml
@@ -2,8 +2,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.michaelelin</groupId>
   <artifactId>Barnyard</artifactId>
-  <version>0.1.1</version>
+  <version>0.1.2</version>
+  <description>Manages summonable pets.</description>
+  <url>https://github.com/Dumbo52/Barnyard</url>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
   <build>
+    <defaultGoal>package</defaultGoal>
     <sourceDirectory>src</sourceDirectory>
     <resources>
       <resource>

--- a/pom.xml
+++ b/pom.xml
@@ -2,14 +2,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.michaelelin</groupId>
   <artifactId>Barnyard</artifactId>
-  <version>0.1.2</version>
+  <version>0.1.3</version>
   <description>Manages summonable pets.</description>
   <url>https://github.com/Dumbo52/Barnyard</url>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <build>
-    <defaultGoal>package</defaultGoal>
+    <defaultGoal>clean package</defaultGoal>
     <sourceDirectory>src</sourceDirectory>
     <resources>
       <resource>
@@ -34,16 +34,16 @@
     </plugins>
   </build>
   <dependencies>
-  	<dependency>
-  		<groupId>org.bukkit</groupId>
-  		<artifactId>bukkit</artifactId>
-  		<version>1.7.9-R0.2</version>
-  	</dependency>
-  	<dependency>
-  		<groupId>com.comphenix.protocol</groupId>
-  		<artifactId>ProtocolLib</artifactId>
-  		<version>3.4.0</version>
-  	</dependency>
+    <dependency>
+      <groupId>org.spigotmc</groupId>
+      <artifactId>spigot-api</artifactId>
+      <version>1.9-R0.1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.comphenix.protocol</groupId>
+      <artifactId>ProtocolLib</artifactId>
+      <version>3.4.0</version>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/src/com/michaelelin/Barnyard/BarnyardPlugin.java
+++ b/src/com/michaelelin/Barnyard/BarnyardPlugin.java
@@ -25,14 +25,14 @@ import com.michaelelin.Barnyard.commands.*;
 public class BarnyardPlugin extends JavaPlugin {
 
     public static final Logger log = Logger.getLogger("Minecraft");
-    
+
     public int MAXIMUM_PETS;
     public List<EntityType> ALLOWED_TYPES;
-    
+
     public PetManager manager;
-    
+
     public ProtocolManager protocolManager;
-    
+
     private Map<String, BarnyardCommand> commands;
 
     @Override
@@ -53,6 +53,7 @@ public class BarnyardPlugin extends JavaPlugin {
                 message(sender, "/pet ride <id>");
                 message(sender, "/pet stack <id> <id> [id...]");
                 message(sender, "/pet name <id> [name]");
+                message(sender, "/pet explode <id>");
             }
             return true;
         }

--- a/src/com/michaelelin/Barnyard/commands/ExplodeCommand.java
+++ b/src/com/michaelelin/Barnyard/commands/ExplodeCommand.java
@@ -16,7 +16,7 @@ import com.comphenix.protocol.utility.MinecraftReflection;
 import com.michaelelin.Barnyard.BarnyardPlugin;
 
 public class ExplodeCommand extends BarnyardCommand {
-    
+
     public ExplodeCommand(BarnyardPlugin plugin) {
         super(plugin, 1);
     }
@@ -34,7 +34,7 @@ public class ExplodeCommand extends BarnyardCommand {
                     plugin.message(sender, "You don't have a pet with ID '" + args[0] + "'.");
                     return true;
                 }
-                pet.getWorld().playSound(pet.getEyeLocation(), Sound.EXPLODE, 1, 1);
+                pet.getWorld().playSound(pet.getEyeLocation(), Sound.ENTITY_GENERIC_EXPLODE, 1, 1);
                 float health = (float) pet.getMaxHealth();
                 Class<Enum> particleEnum = (Class<Enum>) MinecraftReflection.getMinecraftClass("EnumParticle");
                 PacketContainer[] packets = new PacketContainer[3];
@@ -107,5 +107,5 @@ public class ExplodeCommand extends BarnyardCommand {
     public String getDefaultUsage() {
         return "<id>";
     }
-    
+
 }


### PR DESCRIPTION
Made compilable with Spigot 1.9.

Some things are apparently still broken:
- `/pet wear` doesn't work. That may be a change to vanilla.
- Ebeans don't get loaded properly from the database. Spigot issue?

Things that are definitely fixed: 

When Barnyard.db (erroneously) not removed when starting a new map revision,
players' nonexistent pets are still stored. That leads to a NullPointerException
when looking up the World by UUID.

Also improved:
- A README was added.
- The version number was bumped, pom.xml was updated with metadata to be substituted into plugin.yml  \* and a default build action was added so you can just type mvn.
- /pet explode command is now listed in /pet help.
